### PR TITLE
Send params as params, not in URL

### DIFF
--- a/delighted/client.py
+++ b/delighted/client.py
@@ -1,6 +1,5 @@
 from base64 import b64encode
 import json
-import urllib
 import urlparse
 
 import delighted
@@ -44,7 +43,8 @@ class Client(object):
             data = json.dumps(params)
             params = None
 
-        response = self.http_adapter.request(method, url, headers, data, params)
+        response = self.http_adapter.request(method, url, headers, data,
+                                             params)
         return self._handle_response(response)
 
     def _handle_response(self, response):

--- a/delighted/client.py
+++ b/delighted/client.py
@@ -38,15 +38,13 @@ class Client(object):
         url = urlparse.urljoin(delighted.api_base_url, resource)
 
         if method == 'get' and params:
-            encoded_params = urllib.urlencode(list(encode(params)))
-            url_parts = list(urlparse.urlparse(url))
-            url_parts[4] = encoded_params
-            url = urlparse.urlunparse(url_parts)
+            params = dict((key, value) for (key, value) in encode(params))
             data = None
         else:
             data = json.dumps(params)
+            params = None
 
-        response = self.http_adapter.request(method, url, headers, data)
+        response = self.http_adapter.request(method, url, headers, data, params)
         return self._handle_response(response)
 
     def _handle_response(self, response):

--- a/delighted/http_adapter.py
+++ b/delighted/http_adapter.py
@@ -5,7 +5,8 @@ from delighted.http_response import HTTPResponse
 
 class HTTPAdapter(object):
 
-    def request(self, method, uri, headers={}, data=None):
-        resp = requests.request(method, uri, headers=headers, data=data)
+    def request(self, method, uri, headers={}, data=None, params=None):
+        resp = requests.request(method, uri, headers=headers, data=data, \
+            params=params)
 
         return HTTPResponse(resp.status_code, resp.headers, resp.text)

--- a/delighted/http_adapter.py
+++ b/delighted/http_adapter.py
@@ -6,7 +6,7 @@ from delighted.http_response import HTTPResponse
 class HTTPAdapter(object):
 
     def request(self, method, uri, headers={}, data=None, params=None):
-        resp = requests.request(method, uri, headers=headers, data=data, \
-            params=params)
+        resp = requests.request(method, uri, headers=headers, data=data,
+                                params=params)
 
         return HTTPResponse(resp.status_code, resp.headers, resp.text)

--- a/delighted/resource.py
+++ b/delighted/resource.py
@@ -118,5 +118,6 @@ class SurveyResponse(AllResource, CreateableResource,
 class Unsubscribe(AllResource, CreateableResource):
     path = 'unsubscribes'
 
+
 class Bounce(AllResource):
     path = 'bounces'

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -43,9 +43,10 @@ class DelightedTestCase(unittest.TestCase):
         mock.exceptions.RequestException = Exception
         mock.request.side_effect = mock.exceptions.RequestException()
 
-    def check_call(self, meth, url, headers, post_data):
+    def check_call(self, meth, url, headers, post_data, get_params):
         if post_data is not None:
             post_data = json.dumps(post_data)
         self.request_mock.assert_called_once_with(meth, url,
                                                   headers=headers,
-                                                  data=post_data)
+                                                  data=post_data,
+                                                  params=get_params)

--- a/test/test_resource.py
+++ b/test/test_resource.py
@@ -12,7 +12,7 @@ class TestResource(DelightedTestCase):
         self.mock_response(200, {}, data)
 
         metrics = delighted.Metrics.retrieve()
-        self.check_call('get', url, get_headers, {})
+        self.check_call('get', url, get_headers, {}, None)
         self.assertIs(delighted.Metrics, type(metrics))
         self.assertEqual(dict(metrics), data)
         self.assertEqual(metrics.nps, 10)
@@ -24,11 +24,11 @@ class TestResource(DelightedTestCase):
         self.mock_response(200, {}, data)
         since = 1425168000
         until = 1430348400
-        url = 'https://api.delightedapp.com/v1/metrics' + \
-              '?since=1425168000&until=1430348400'
+        url = 'https://api.delightedapp.com/v1/metrics'
 
         metrics = delighted.Metrics.retrieve(since=since, until=until)
-        self.check_call('get', url, get_headers, None)
+        self.check_call('get', url, get_headers, None, \
+            {'since': 1425168000, 'until': 1430348400})
         self.assertIs(delighted.Metrics, type(metrics))
         self.assertEqual(dict(metrics), data)
         self.assertEqual(metrics.nps, 10)
@@ -46,7 +46,7 @@ class TestResource(DelightedTestCase):
         self.assertEqual(dict(person), {'email': email})
         self.assertEqual(person.email, email)
         self.assertEqual('123', person.id)
-        self.check_call('post', url, post_headers, {'email': email})
+        self.check_call('post', url, post_headers, {'email': email}, None)
 
     def test_unsubscribing_a_person(self):
         email = 'person@example.com'
@@ -55,7 +55,7 @@ class TestResource(DelightedTestCase):
         self.mock_response(200, {}, {'ok': True})
 
         delighted.Unsubscribe.create(person_email=email)
-        self.check_call('post', url, post_headers, data)
+        self.check_call('post', url, post_headers, data, None)
 
     def test_deleting_pending_survey_requests_for_a_person(self):
         email = 'foo@bar.com'
@@ -66,7 +66,7 @@ class TestResource(DelightedTestCase):
         result = delighted.SurveyRequest.delete_pending(person_email=email)
         self.assertIs(dict, type(result))
         self.assertEqual({'ok': True}, result)
-        self.check_call('delete', url, post_headers, {})
+        self.check_call('delete', url, post_headers, {}, None)
 
     def test_creating_a_survey_response(self):
         url = 'https://api.delightedapp.com/v1/survey_responses'
@@ -80,11 +80,10 @@ class TestResource(DelightedTestCase):
         self.assertEqual(10, survey_response.score)
         self.assertEqual('456', survey_response.id)
         resp = {'person': '123', 'score': 10}
-        self.check_call('post', url, post_headers, resp)
+        self.check_call('post', url, post_headers, resp, None)
 
     def test_retrieving_a_survey_response_expand_person(self):
-        url = 'https://api.delightedapp.com/v1/survey_responses/456' + \
-              '?expand%5B%5D=person'
+        url = 'https://api.delightedapp.com/v1/survey_responses/456'
         data = {'id': '456',
                 'person': {'id': '123', 'email': 'foo@bar.com'},
                 'score': 10}
@@ -92,7 +91,7 @@ class TestResource(DelightedTestCase):
 
         survey_response = delighted.SurveyResponse.retrieve('456',
                                                             expand=['person'])
-        self.check_call('get', url, get_headers, None)
+        self.check_call('get', url, get_headers, None, {'expand[]': 'person'})
         self.assertIs(delighted.SurveyResponse, type(survey_response))
         self.assertIs(delighted.Person, type(survey_response.person))
         self.assertEqual({'person': '123', 'score': 10}, dict(survey_response))
@@ -113,7 +112,7 @@ class TestResource(DelightedTestCase):
         survey_response.person = '123'
         survey_response.score = 10
         self.assertIs(delighted.SurveyResponse, type(survey_response.save()))
-        self.check_call('put', url, post_headers, data)
+        self.check_call('put', url, post_headers, data, None)
         resp = {'person': '123', 'score': 10}
         self.assertEqual(resp, dict(survey_response))
         self.assertEqual('123', survey_response.person)
@@ -121,13 +120,13 @@ class TestResource(DelightedTestCase):
         self.assertEqual('456', survey_response.id)
 
     def test_listing_all_survey_responses(self):
-        url = 'https://api.delightedapp.com/v1/survey_responses?order=desc'
+        url = 'https://api.delightedapp.com/v1/survey_responses'
         resp1 = {'id': '123', 'comment': 'One'}
         resp2 = {'id': '456', 'comment': 'Two'}
         self.mock_response(200, {}, [resp1, resp2])
 
         survey_responses = delighted.SurveyResponse.all(order='desc')
-        self.check_call('get', url, get_headers, None)
+        self.check_call('get', url, get_headers, None, {'order': 'desc'})
         self.assertIs(list, type(survey_responses))
         self.assertIs(delighted.SurveyResponse, type(survey_responses[0]))
         self.assertEqual({'comment': 'One'}, dict(survey_responses[0]))
@@ -139,8 +138,7 @@ class TestResource(DelightedTestCase):
         self.assertEqual('456', survey_responses[1].id)
 
     def test_listing_all_survey_responses_expand_person(self):
-        url = 'https://api.delightedapp.com/v1/' + \
-              'survey_responses?expand%5B%5D=person'
+        url = 'https://api.delightedapp.com/v1/survey_responses'
         resp1 = {'id': '123', 'comment': 'One',
                  'person': {'id': '123', 'email': 'foo@bar.com'}}
         resp2 = {'id': '456', 'comment': 'Two',
@@ -149,7 +147,7 @@ class TestResource(DelightedTestCase):
 
         survey_responses = delighted.SurveyResponse.all(expand=['person'])
         resp1 = {'person': '123', 'comment': 'One'}
-        self.check_call('get', url, get_headers, None)
+        self.check_call('get', url, get_headers, None, {'expand[]': 'person'})
         self.assertIs(list, type(survey_responses))
         self.assertIs(delighted.SurveyResponse, type(survey_responses[0]))
         self.assertEqual(resp1, dict(survey_responses[0]))
@@ -172,7 +170,7 @@ class TestResource(DelightedTestCase):
         self.mock_response(200, {}, [resp1])
 
         unsubscribes = delighted.Unsubscribe.all()
-        self.check_call('get', url, get_headers, {})
+        self.check_call('get', url, get_headers, {}, None)
         self.assertIs(list, type(unsubscribes))
         self.assertIs(delighted.Unsubscribe, type(unsubscribes[0]))
         self.assertEqual(resp1, dict(unsubscribes[0]))
@@ -183,7 +181,7 @@ class TestResource(DelightedTestCase):
         self.mock_response(200, {}, [resp1])
 
         bounces = delighted.Bounce.all()
-        self.check_call('get', url, get_headers, {})
+        self.check_call('get', url, get_headers, {}, None)
         self.assertIs(list, type(bounces))
         self.assertIs(delighted.Bounce, type(bounces[0]))
         self.assertEqual(resp1, dict(bounces[0]))


### PR DESCRIPTION
This change sends the GET query parameters to the request method as a dictionary (modified to include Delighted's parameter-naming conventions for arrays and hashes) rather than as a pre-munged string. This fixes test issues where params could be serialized into the URL in a different order than the test expected, causing spurious test failures.
