### PR TITLE
Fix SyntaxWarning with Python 3.8+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.1 (2021-01-13)
+
+Bugfixes:
+
+- Fix incorrect usage of `is not`, emiting SyntaxWarning in Python 3.8+
+
 ## 4.0.0 (2020-03-18)
 
 Features:

--- a/delighted/__init__.py
+++ b/delighted/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'delighted'
-__version__ = '4.0.0'
+__version__ = '4.0.1'
 __author__ = 'Ben Turner'
 __license__ = 'MIT'
 

--- a/delighted/resource.py
+++ b/delighted/resource.py
@@ -31,7 +31,7 @@ class Resource(dict):
             self[k] = v
 
     def __getattr__(self, k):
-        if k[0] == '_' and k is not '_attrs':
+        if k[0] == '_' and k != '_attrs':
             raise AttributeError(k)
 
         try:


### PR DESCRIPTION
New warning introduced in Python 3.8 (see https://docs.python.org/3/whatsnew/3.8.html#changes-in-python-behavior)